### PR TITLE
Fix WP-CLI fatal error on plugin deactivate

### DIFF
--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -58,7 +58,7 @@ class Index_Wp_Users_For_Speed {
     $this->plugin_name = INDEX_WP_USERS_FOR_SPEED_NAME;
 
     /* stuff required for all back-end. cron, REST api operations. */
-    if ( wp_doing_cron() || wp_doing_ajax() || is_admin() || wp_is_json_request() || wp_is_xml_request() ) {
+    if ( wp_doing_cron() || wp_doing_ajax() || is_admin() || wp_is_json_request() || wp_is_xml_request() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
       require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/wordpress-hooks.php';
       require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/i18n.php';
       require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/user-handler.php';


### PR DESCRIPTION
Fix fatal error undefined class when plugin is deactivated via WP-CLI.