### PR TITLE
Before counting array, make sure it's an array

### DIFF
--- a/admin/user-handler.php
+++ b/admin/user-handler.php
@@ -764,7 +764,7 @@ class UserHandler extends WordPressHooks {
   public function filter__rest_user_query( $query_args, $request ) {
     $threshold = get_option( $this->options_name )['quickedit_threshold_limit'];
     $editors   = $this->indexer->getEditors();
-    if ( count( $editors ) <= $threshold ) {
+    if ( $editors && count( $editors ) <= $threshold ) {
       $query_args['include'] = $editors;
     }
     $this->doingRestQuery = true;


### PR DESCRIPTION
Resolves this PHP 8 error:

```
Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in /…/wp-content/plugins/index-wp-users-for-speed/admin/user-handler.php:767
```

Related to #10

Ideally, the `getEditors()` method would return an empty array, but this check is sufficient to address the error.