### PR TITLE
Update user-handler.php

### DIFF
--- a/admin/user-handler.php
+++ b/admin/user-handler.php
@@ -265,6 +265,20 @@ class UserHandler extends WordPressHooks {
    * @noinspection PhpUnused
    */
   public function filter__wp_dropdown_users_args( $query_args, $parsed_args ) {
+    /* short-circuit if only pre-determined users are already set in $query_args */
+    if ( array_key_exists( 'include', $query_args ) 
+        && count( array_filter( wp_array_slice_assoc( $query_args, 
+                                                     array('include', 
+                                                           'exclude', 
+                                                           'role', 
+                                                           'role__in', 
+                                                           'role__not_in', 
+                                                           'capability', 
+                                                           'capability__in', 
+                                                           'capability__not_in'
+                                                          ) ) ) ) == 1 ) {
+        return $query_args;
+    }
     /* is this about posts or pages */
     if ( array_key_exists( 'capability', $query_args ) ) {
       $this->requestedCapabilities = $query_args['capability'];

--- a/admin/user-handler.php
+++ b/admin/user-handler.php
@@ -266,17 +266,21 @@ class UserHandler extends WordPressHooks {
    */
   public function filter__wp_dropdown_users_args( $query_args, $parsed_args ) {
     /* short-circuit if only pre-determined users are already set in $query_args */
-    if ( array_key_exists( 'include', $query_args ) 
-        && count( array_filter( wp_array_slice_assoc( $query_args, 
-                                                     array('include', 
-                                                           'exclude', 
-                                                           'role', 
-                                                           'role__in', 
-                                                           'role__not_in', 
-                                                           'capability', 
-                                                           'capability__in', 
-                                                           'capability__not_in'
-                                                          ) ) ) ) == 1 ) {
+    $query_non_empty_args = array_filter( 
+      wp_array_slice_assoc( $query_args, 
+                            array('include', 
+                                  'exclude', 
+                                  'role', 
+                                  'role__in', 
+                                  'role__not_in', 
+                                  'capability', 
+                                  'capability__in', 
+                                  'capability__not_in'
+                                 ) 
+                          ) 
+    );
+    if ( array_key_exists( 'include', $query_non_empty_args ) 
+        && count( $query_non_empty_args ) == 1 ) {
         return $query_args;
     }
     /* is this about posts or pages */


### PR DESCRIPTION
Check if only pre-determined users are already set in the arguments to the query, in which case some upstream filter has already set which specific users to show and we don't need to build a query for the authors. 

Co-Authors Plus does this by setting only the include argument with user_id 0 in the filter quick_edit_dropdown_authors_args to suppress the regular author dropdown and show only the co-authors selection box. Fixes #22 