### PR TITLE
fix: progressive slowdown in `PopulateMetaIndexRoles` task

### DIFF
--- a/includes/tasks/populate-meta-index-roles.php
+++ b/includes/tasks/populate-meta-index-roles.php
@@ -53,7 +53,6 @@ class PopulateMetaIndexRoles extends Task {
     global $wpdb;
     $this->startChunk();
 
-    $queries    = $this->makeIndexerQueries( $this->roles );
     $transStart = $this->currentStart;
     $indexer    = Indexer::getInstance();
     $transStart = $indexer->getNextUserId( $transStart );
@@ -67,10 +66,11 @@ class PopulateMetaIndexRoles extends Task {
       $q        = $wpdb->prepare( $query, $wpdb->prefix . 'capabilities', $transStart, $transEnd );
       $this->doQuery( $q );
 
+      /* Build queries with user_id range baked into each UNION subquery
+       * so MySQL uses the (user_id, meta_key) index per chunk. */
+      $queries = $this->makeIndexerQueries( $this->roles, $transStart, $transEnd );
       foreach ( $queries as $query ) {
-        $query .= ' WHERE a.user_id >= %d AND a.user_id < %d';
-        $q     = $wpdb->prepare( $query, $transStart, $transEnd );
-        $this->doQuery( $q );
+        $this->doQuery( $query );
       }
       $this->doQuery( 'COMMIT' );
       $transStart         = $transEnd;
@@ -92,7 +92,7 @@ class PopulateMetaIndexRoles extends Task {
     return $done;
   }
 
-  private function makeIndexerQueries( $roles ) {
+  private function makeIndexerQueries( $roles, $rangeStart, $rangeEnd ) {
     global $wpdb;
 
     $results = [];
@@ -101,7 +101,9 @@ class PopulateMetaIndexRoles extends Task {
     $capabilitiesKey = $wpdb->prefix . 'capabilities';
     $insertUnions    = [];
     $deleteUnions    = [];
-    /* This one finds the role index metakeys to insert into usermeta. This is idempotent. */
+    /* This one finds the role index metakeys to insert into usermeta. This is idempotent.
+     * The user_id range is applied inside each subquery so MySQL can use
+     * the (user_id, meta_key) index instead of scanning the full table. */
     $insertTemplate = /** @lang text */
       "SELECT a.user_id, %s meta_key
          FROM $wpdb->usermeta a
@@ -110,7 +112,8 @@ class PopulateMetaIndexRoles extends Task {
                AND b.meta_key = %s
         WHERE a.meta_key = %s
           AND a.meta_value LIKE CONCAT('%%', %s, '%%')
-          AND b.user_id IS NULL";
+          AND b.user_id IS NULL
+          AND a.user_id >= %d AND a.user_id < %d";
     /* This one finds the usermeta rows with wrong capabilities, to delete.
      * We want these delete and insert operations to be idempotent,
      * doing nothing if the proper row is already present.
@@ -123,12 +126,13 @@ class PopulateMetaIndexRoles extends Task {
                AND b.meta_key = %s
                AND b.meta_value LIKE CONCAT('%%', %s, '%%')
         WHERE a.meta_key = %s
-          AND b.umeta_id IS NULL";
+          AND b.umeta_id IS NULL
+          AND a.user_id >= %d AND a.user_id < %d";
 
     foreach ( $roles as $role ) {
       $prefixedRole   = $prefix . $role;
-      $insertUnions[] = $wpdb->prepare( $insertTemplate, $prefixedRole, $prefixedRole, $capabilitiesKey, $wpdb->esc_like( $role ) );
-      $deleteUnions[] = $wpdb->prepare( $deleteTemplate, $capabilitiesKey, $wpdb->esc_like( $role ), $prefixedRole );
+      $insertUnions[] = $wpdb->prepare( $insertTemplate, $prefixedRole, $prefixedRole, $capabilitiesKey, $wpdb->esc_like( $role ), $rangeStart, $rangeEnd );
+      $deleteUnions[] = $wpdb->prepare( $deleteTemplate, $capabilitiesKey, $wpdb->esc_like( $role ), $prefixedRole, $rangeStart, $rangeEnd );
     }
 
     $union = implode( ' UNION ALL ', $deleteUnions );


### PR DESCRIPTION
## Fix progressive slowdown in `PopulateMetaIndexRoles` task

### Problem

On a multisite installation with ~2.7M users and 13 roles, the `PopulateMetaIndexRoles` task becomes progressively slower as it advances. Observed via WP-Cron execution logs:

- Early batches: ~15 seconds each
- After 5% progress: ~3 minutes each
- After 10% progress: ~7 minutes each
- Projected total: 100+ hours (and growing)

Memory remains stable (~135 MB), confirming this is a database-side issue, not a PHP memory leak.

### Root cause

`makeIndexerQueries()` builds two SQL statements (DELETE stale + INSERT missing index entries), each containing a `UNION` of N subqueries (one per role). Each subquery performs a `LEFT JOIN` anti-join on `wp_usermeta` against itself.

The `user_id` range filter was only appended to the **outer** wrapper query in `doChunk()`:

```php
foreach ( $queries as $query ) {
    $query .= ' WHERE a.user_id >= %d AND a.user_id < %d';
    $q     = $wpdb->prepare( $query, $transStart, $transEnd );
    $this->doQuery( $q );
}
```

Each of the N UNION subqueries scanned **all** `wp_capabilities` rows in `wp_usermeta` on every chunk, regardless of the chunk size being processed. MySQL cannot push the outer predicate down into derived tables with UNION and anti-joins.

As the task INSERTs new index rows, `wp_usermeta` grows, and the unranged LEFT JOINs scan progressively more rows — causing the linear slowdown.

### Fix

Push the `user_id` range filter **inside** each UNION subquery so MySQL can use the `(user_id, meta_key)` index for a tight range scan:

- `makeIndexerQueries()` now accepts `$rangeStart` and `$rangeEnd` parameters. Both `$insertTemplate` and `$deleteTemplate` include `AND a.user_id >= %d AND a.user_id < %d` inside each subquery, with range values passed to `$wpdb->prepare()` per role.
- `doChunk()` calls `makeIndexerQueries()` inside the `while` loop with the current chunk's `$transStart, $transEnd`. The outer `WHERE` append and secondary `prepare()` are removed — queries are fully prepared by `makeIndexerQueries()`.

### Impact

| Metric | Before (per chunk) | After (per chunk) |
|---|---|---|
| Rows scanned per subquery | All capability rows (~N million) | ~chunk_size rows |
| Degrades as table grows | Yes (root cause) | No |

### Behavioral equivalence

Filtering a UNION by `user_id` range on the outer query produces the same rows as UNIONing range-filtered subqueries:

- **INSERT anti-join**: The range on `a` (capabilities rows) restricts which users are checked. The LEFT JOIN on `b` (index entries) is NOT range-restricted — it correctly checks the full table for each user's existing index entry.
- **DELETE anti-join**: The range on `a` (index rows) restricts which stale entries are checked. The LEFT JOIN on `b` (capabilities) is NOT range-restricted — it correctly checks the full capabilities for each user.
- **Idempotency preserved**: Anti-join pattern ensures re-running the same chunk is a no-op.
- **Transaction boundaries unchanged**: BEGIN / FOR UPDATE / DELETE / INSERT / COMMIT sequence is identical.
- **Progress tracking unchanged**: `currentStart`, `fractionComplete`, `setStatus()` all untouched.

### Compatibility

`makeIndexerQueries()` is `private` — only callable from `doChunk()`, which is the single entry point for both WP-Cron execution (`doTaskStep()` → `doChunk()`) and any direct callers. No other code in the plugin calls `makeIndexerQueries()`.

### How to reproduce

1. Install on a site with 500K+ users and multiple roles
2. Trigger the populate meta index roles task (admin UI "Rebuild Now" or cron)
3. Observe batch execution times increasing linearly as the task progresses

### File changed

`includes/tasks/populate-meta-index-roles.php`

### Tests

@sboisvert and @mehamasum (**XWP**) are working on a **CLI command** that does the same thing as the **cron job** does, but instead of cron, it runs with `wp cli` so we can monitor progress. That was the way I have noticed this issue. Using that CLI command, I had these results below.

### Before

```bash
wp index-wp-users populate-meta-index-roles --url=platform.dailykos.com
Starting populate meta index roles task...
Batch size: 5000, Chunk size: 50, Timeout: 0 seconds
Total users: 2,745,569
User ID range: 1 to 2,745,586
Indexing 13 roles: administrator, editor, author, contributor, subscriber, vip_support, vip_support_inactive, wpfs_no_access, wpfs_basic, wpfs_bronze, wpfs_silver, wpfs_gold, wpfs_all_access
Processing approximately 550 batches
Processing users  0  % [>                            ] 0:00 / 0:00
Current memory usage: 135.11 MB
Processing users  1  % [===>                         ] 2:28   / 230:51
Progress: 1.8% | Batch 10 | Elapsed: 2 min 32 sec | Memory: 135.12 MB
Processing users  3  % [======>                      ] 8:16   / 473:36
Current memory usage: 135.13 MB
Processing users  3  % [=======>                     ] 10:18  / 555:30
Progress: 3.6% | Batch 20 | Elapsed: 10 min 22 sec | Memory: 135.13 MB
Processing users  4  % [=========>                   ] 15:38  / 771:21
Current memory usage: 135.14 MB
Processing users  5  % [==========>                  ] 22:13  / 933:03
Current memory usage: 135.14 MB
Processing users  5  % [===========>                 ] 25:59   / 1021:15
Progress: 5.5% | Batch 30 | Elapsed: 26 min 3 sec | Memory: 135.15 MB
Processing users  6  % [============>                ] 32:17   / 1183:20
Current memory usage: 135.15 MB
Processing users  6  % [=============>               ] 39:08   / 1256:30
Current memory usage: 135.16 MB
Processing users  7  % [==============>              ] 46:35   / 1374:07
Current memory usage: 135.16 MB
Processing users  7  % [===============>             ] 49:14   / 1427:21
Progress: 7.3% | Batch 40 | Elapsed: 49 min 18 sec | Memory: 135.16 MB
Processing users  7  % [================>            ] 54:48   / 1512:49
Current memory usage: 135.17 MB
Processing users  8  % [================>            ] 60:39   / 1589:55
Current memory usage: 135.17 MB
Processing users  8  % [=================>           ] 66:45   / 1648:15
Current memory usage: 135.17 MB
Processing users  8  % [==================>          ] 73:09   / 1751:38
Current memory usage: 135.17 MB
Processing users  9  % [===================>         ] 79:55   / 1839:17
Progress: 9.1% | Batch 50 | Elapsed: 1 hours 19 min | Memory: 135.18 MB
Processing users  9  % [===================>         ] 87:01   / 1947:28
Current memory usage: 135.18 MB
Processing users  9  % [====================>        ] 94:25   / 2019:58
Current memory usage: 135.18 MB
Processing users  10 % [=====================>       ] 102:13  / 2108:30
Current memory usage: 135.18 MB
Processing users  10 % [======================>      ] 110:17  / 2200:52
Current memory usage: 135.19 MB
Processing users  10 % [=======================>     ] 118:40  / 2294:20
Progress: 10.9% | Batch 60 | Elapsed: 1 hours 58 min | Memory: 135.19 MB
Processing users  11 % [=======================>     ] 127:28  / 2403:15
Current memory usage: 135.19 MB
Processing users  11 % [========================>    ] 136:41  / 2521:46
Current memory usage: 135.2 MB
Processing users  12 % [=========================>   ] 146:20  / 2646:39
Current memory usage: 135.2 MB
Processing users  12 % [==========================>  ] 156:22  / 2732:56
Current memory usage: 135.2 MB
Processing users  12 % [==========================>  ] 161:31  / 2794:24
Current memory usage: 135.2 MB
Processing users  12 % [==========================>  ] 166:48  / 2863:01
Progress: 12.7% | Batch 70 | Elapsed: 2 hours 46 min | Memory: 135.2 MB
Processing users  12 % [===========================> ] 172:10  / 2913:34
Current memory usage: 135.21 MB
Processing users  13 % [===========================> ] 177:43  / 3008:39
Current memory usage: 135.21 MB
Processing users  13 % [============================>] 183:27  / 3109:34
Current memory usage: 135.21 MB
Processing users  13 % [============================>] 189:09  / 3094:00
Current memory usage: 135.21 MB
Processing users  13 % [============================>] 194:56  / 3139:00
Current memory usage: 135.21 MB
...
```

### After

```bash
wp index-wp-users populate-meta-index-roles --url=platform.dailykos.com
Starting populate meta index roles task...
Batch size: 5000, Chunk size: 50, Timeout: 0 seconds
Total users: 2,745,569
User ID range: 1 to 2,745,586
Indexing 13 roles: administrator, editor, author, contributor, subscriber, vip_support, vip_support_inactive, wpfs_no_access, wpfs_basic, wpfs_bronze, wpfs_silver, wpfs_gold, wpfs_all_access
Processing approximately 550 batches
Processing users  0  % [>                                                        ] 0:00 / 0:00
Current memory usage: 135.14 MB
Processing users  1  % [===>                                                     ] 0:11 / 9:30
Progress: 1.8% | Batch 10 | Elapsed: 12 seconds | Memory: 135.15 MB
Processing users  3  % [=======>                                                 ] 0:24  / 12:13
Progress: 3.6% | Batch 20 | Elapsed: 25 seconds | Memory: 135.17 MB
Processing users  5  % [===========>                                             ] 0:36  / 11:37
Progress: 5.5% | Batch 30 | Elapsed: 37 seconds | Memory: 135.19 MB
Processing users  7  % [===============>                                         ] 0:50  / 11:30
Progress: 7.3% | Batch 40 | Elapsed: 51 seconds | Memory: 135.2 MB
Processing users  9  % [===================>                                     ] 1:03  / 12:10
Progress: 9.1% | Batch 50 | Elapsed: 1 min 4 sec | Memory: 135.21 MB
Processing users  10 % [=======================>                                 ] 1:16  / 11:57
Progress: 10.9% | Batch 60 | Elapsed: 1 min 17 sec | Memory: 135.23 MB
Processing users  12 % [===========================>                             ] 1:30  / 12:32
Progress: 12.7% | Batch 70 | Elapsed: 1 min 31 sec | Memory: 135.24 MB
Processing users  14 % [===============================>                         ] 1:45  / 14:28
Progress: 14.6% | Batch 80 | Elapsed: 1 min 46 sec | Memory: 135.25 MB
Processing users  16 % [===================================>                     ] 2:00  / 14:12
Progress: 16.4% | Batch 90 | Elapsed: 2 min 1 sec | Memory: 135.27 MB
Processing users  18 % [=======================================>                 ] 2:16  / 14:16
Progress: 18.2% | Batch 100 | Elapsed: 2 min 17 sec | Memory: 135.28 MB
Processing users  20 % [===========================================>             ] 2:30  / 12:45
Progress: 20.0% | Batch 110 | Elapsed: 2 min 31 sec | Memory: 135.29 MB
Processing users  21 % [==============================================>          ] 2:46  / 14:00
Progress: 21.9% | Batch 120 | Elapsed: 2 min 47 sec | Memory: 135.31 MB
Processing users  23 % [==================================================>      ] 3:01  / 14:27
Progress: 23.7% | Batch 130 | Elapsed: 3 min 2 sec | Memory: 135.32 MB
Processing users  25 % [======================================================>  ] 3:18  / 15:50
Progress: 25.5% | Batch 140 | Elapsed: 3 min 19 sec | Memory: 135.34 MB
Processing users  26 % [========================================================>] 3:25  / 14:00
...
```